### PR TITLE
Fix syntax error in testem config file

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -21,7 +21,7 @@ module.exports = {
         '--window-size=1440,900'
       ].filter(Boolean)
     }
-  }
+  },
   proxies: {
     '/backstop': {
       target: 'http://localhost:3000',


### PR DESCRIPTION
Missing comma in testem config file.

It would be nice to have some linter catch these kind of errors. :) 